### PR TITLE
Add backend integration E2E coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ yarn-error.log
 .sass-cache/
 /connect.lock
 /coverage
+/playwright-report
+/test-results
+frontend.local*.log
 /libpeerconnection.log
 testem.log
 /typings

--- a/e2e/rakium-backend-integration.spec.ts
+++ b/e2e/rakium-backend-integration.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+
+const apiUrl = process.env.E2E_API_URL ?? 'http://localhost:3000/api';
+const adminEmail = process.env.E2E_ADMIN_EMAIL ?? 'admin@rakium.com';
+const adminPassword = process.env.E2E_ADMIN_PASSWORD ?? 'admin123';
+
+test.beforeAll(async ({ request }) => {
+  const docsResponse = await request.get(apiUrl);
+  expect(docsResponse.ok()).toBeTruthy();
+
+  const loginResponse = await request.post(`${apiUrl}/auth/login`, {
+    data: {
+      email: adminEmail,
+      password: adminPassword,
+    },
+  });
+  expect(loginResponse.ok()).toBeTruthy();
+});
+
+test('public home loads against the backend without app errors', async ({ page }) => {
+  const pageErrors: string[] = [];
+  const failedRequests: string[] = [];
+  const failedApiResponses: string[] = [];
+
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message);
+  });
+  page.on('requestfailed', (request) => {
+    const url = request.url();
+    if (url.startsWith(apiUrl)) {
+      failedRequests.push(url);
+    }
+  });
+  page.on('response', (response) => {
+    const url = response.url();
+    if (url.startsWith(apiUrl) && response.status() >= 400) {
+      failedApiResponses.push(`${response.status()} ${url}`);
+    }
+  });
+
+  await page.goto('/');
+
+  await expect(page.getByRole('heading', { name: /Transformamos tu visi/i })).toBeVisible();
+  await expect(page.getByRole('navigation')).toContainText('Portafolio');
+  await expect(page.locator('#projects')).toBeVisible();
+  await expect(page.getByText('Proyecto Ejemplo')).toBeVisible();
+
+  expect(pageErrors).toEqual([]);
+  expect(failedRequests).toEqual([]);
+  expect(failedApiResponses).toEqual([]);
+});
+
+test('admin can log in and reach the projects dashboard', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByPlaceholder('admin@rakium.com').fill(adminEmail);
+  await page.locator('input[type="password"]').fill(adminPassword);
+  await page.locator('button[type="submit"]').click();
+
+  await expect(page).toHaveURL(/\/admin$/);
+  await expect(page.getByText(/Gestiona tus proyectos/i)).toBeVisible();
+  await expect(page.getByText('Proyecto Ejemplo')).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@angular-devkit/build-angular": "^19.0.1",
         "@angular/cli": "^19.2.6",
         "@angular/compiler-cli": "^19.0.0",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.1.3",
         "@types/express": "^4.17.17",
         "@types/jasmine": "~5.1.0",
@@ -4729,6 +4730,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@primeng/themes": {
@@ -12333,6 +12350,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "serve:ssr": "node dist/rakium-dev/server/server.mjs",
     "serve:ssr:client": "node scripts/serve-client-only.js",
     "build:ssr": "ng build",
-    "prerender": "ng run rakium-dev:prerender"
+    "prerender": "ng run rakium-dev:prerender",
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed"
   },
   "private": true,
   "dependencies": {
@@ -46,6 +48,7 @@
     "@angular-devkit/build-angular": "^19.0.1",
     "@angular/cli": "^19.2.6",
     "@angular/compiler-cli": "^19.0.0",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.1.3",
     "@types/express": "^4.17.17",
     "@types/jasmine": "~5.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const frontendPort = Number(process.env.E2E_FRONTEND_PORT ?? 4201);
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? `http://localhost:${frontendPort}`,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: `npm run start:local -- --port ${frontendPort}`,
+    url: `http://localhost:${frontendPort}`,
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/src/app/core/config/rakium.config.ts
+++ b/src/app/core/config/rakium.config.ts
@@ -1,5 +1,7 @@
+import { environment } from '../../../environments/environment';
+
 /**
  * ID del cliente en rakium-be cuyos proyectos se muestran en la sección "Casos de Éxito".
  * Los proyectos se obtienen vía GET /projects/client/:clientId/public
  */
-export const RAKIUM_CLIENT_ID = 'a49284fc-c5cc-471e-a4f7-1fb71925c1e3';
+export const RAKIUM_CLIENT_ID = environment.rakiumClientId;

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: 'https://rakium-be-production.up.railway.app/api',
+  rakiumClientId: 'a49284fc-c5cc-471e-a4f7-1fb71925c1e3',
 };

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:3000/api',
+  rakiumClientId: '98280818-e80a-4305-a887-a74a3a6c2ecb',
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://rakium-backend-production.up.railway.app/api'
-}; 
+  apiUrl: 'https://rakium-backend-production.up.railway.app/api',
+  rakiumClientId: 'a49284fc-c5cc-471e-a4f7-1fb71925c1e3',
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: 'https://rakium-be-production.up.railway.app/api',
+  rakiumClientId: 'a49284fc-c5cc-471e-a4f7-1fb71925c1e3',
 };


### PR DESCRIPTION
## Summary
- add Playwright E2E setup for rakium-dev
- validate public home loads projects from rakium-be local API
- validate admin login reaches the projects dashboard
- move the Rakium client id into Angular environment config so local E2E can target seeded backend data
- ignore Playwright reports and local frontend logs

## Validation
- npm.cmd run e2e
- npm.cmd run build

## Notes
- Production/development client ids stay on the existing production client id.
- Local config uses the seeded backend client id from rakium-be.