### PR TITLE
Add Rakium password reset flow

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,6 +7,8 @@ export const routes: Routes = [
   { path: '', loadComponent: () => import('./pages/home/home.component').then(m => m.HomeComponent) },
   { path: 'proyecto/:id', loadComponent: () => import('./components/project-detail/project-detail.component').then(m => m.ProjectDetailComponent) },
   { path: 'login', loadComponent: () => import('./components/auth/login/login.component').then(m => m.LoginComponent) },
+  { path: 'forgot-password', loadComponent: () => import('./components/auth/forgot-password/forgot-password.component').then(m => m.ForgotPasswordComponent) },
+  { path: 'reset-password', loadComponent: () => import('./components/auth/reset-password/reset-password.component').then(m => m.ResetPasswordComponent) },
   {
     path: 'admin',
     canActivate: [authGuard],

--- a/src/app/components/auth/forgot-password/forgot-password.component.ts
+++ b/src/app/components/auth/forgot-password/forgot-password.component.ts
@@ -1,0 +1,113 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { finalize } from 'rxjs';
+import { LucideAngularModule, ArrowLeft, Loader2, Mail } from 'lucide-angular';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-forgot-password',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink, LucideAngularModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-4">
+      <div class="w-full max-w-md">
+        <div class="bg-slate-800/80 backdrop-blur-sm border border-slate-700 rounded-2xl shadow-2xl overflow-hidden">
+          <div class="bg-gradient-to-r from-blue-600 to-indigo-600 text-white p-8 text-center">
+            <div class="flex items-center justify-center">
+              <img src="/assets/logos/Logotipo - Blanco.svg" alt="Rakium Logo" class="h-12 w-auto" />
+            </div>
+          </div>
+
+          <div class="p-8 pb-10">
+            <a routerLink="/login" class="inline-flex items-center gap-2 text-sm font-medium text-slate-300 hover:text-white transition-colors mb-6">
+              <lucide-icon [name]="arrowLeftIcon" size="18"></lucide-icon>
+              Volver al login
+            </a>
+
+            <div class="space-y-2 mb-8">
+              <h1 class="text-2xl font-semibold text-white">Recuperar contraseña</h1>
+              <p class="text-sm text-slate-400">Ingresá tu email y te mandamos un link para crear una nueva contraseña.</p>
+            </div>
+
+            <form (ngSubmit)="onSubmit()" class="space-y-6">
+              <div class="space-y-2">
+                <label for="email" class="block text-sm font-semibold text-slate-200">Email</label>
+                <div class="relative">
+                  <input
+                    id="email"
+                    type="email"
+                    placeholder="tu@email.com"
+                    [(ngModel)]="email"
+                    name="email"
+                    required
+                    class="w-full px-4 py-3 pr-12 bg-slate-700/60 border border-slate-500/50 rounded-xl text-white placeholder-slate-400 focus:border-blue-400 focus:ring-1 focus:ring-blue-400/30 transition-all duration-200"
+                  />
+                  <lucide-icon [name]="mailIcon" size="20" class="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400"></lucide-icon>
+                </div>
+              </div>
+
+              @if (message()) {
+                <div class="rounded-xl border border-emerald-700/70 bg-emerald-900/20 px-4 py-3 text-sm text-emerald-100">
+                  {{ message() }}
+                </div>
+              }
+
+              @if (errorMessage()) {
+                <div class="rounded-xl border border-red-800 bg-red-900/20 px-4 py-3 text-sm text-red-200">
+                  {{ errorMessage() }}
+                </div>
+              }
+
+              <button
+                type="submit"
+                [disabled]="loading() || !email"
+                class="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 disabled:from-slate-600 disabled:to-slate-700 text-white font-semibold py-4 px-8 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 flex items-center justify-center mt-2 disabled:cursor-not-allowed"
+              >
+                @if (!loading()) {
+                  <span>Enviar link</span>
+                } @else {
+                  <span class="flex items-center">
+                    <lucide-icon [name]="loaderIcon" size="20" class="animate-spin mr-2"></lucide-icon>
+                    Enviando...
+                  </span>
+                }
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [`:host { display: block; }`],
+})
+export class ForgotPasswordComponent {
+  private readonly authService = inject(AuthService);
+
+  email = '';
+  readonly loading = signal(false);
+  readonly message = signal('');
+  readonly errorMessage = signal('');
+
+  readonly arrowLeftIcon = ArrowLeft;
+  readonly loaderIcon = Loader2;
+  readonly mailIcon = Mail;
+
+  onSubmit(): void {
+    if (!this.email || this.loading()) return;
+
+    this.loading.set(true);
+    this.message.set('');
+    this.errorMessage.set('');
+
+    this.authService
+      .forgotPassword(this.email)
+      .pipe(finalize(() => this.loading.set(false)))
+      .subscribe({
+        next: (response) => this.message.set(response.message),
+        error: () => this.errorMessage.set('No pudimos enviar el email. Intentá nuevamente.'),
+      });
+  }
+}

--- a/src/app/components/auth/login/login.component.ts
+++ b/src/app/components/auth/login/login.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, signal, effect, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { AuthService } from '../../../core/services/auth.service';
 import { MessageModule } from 'primeng/message';
 import { LucideAngularModule, Eye, EyeOff, Loader2 } from 'lucide-angular';
@@ -9,7 +9,7 @@ import { LucideAngularModule, Eye, EyeOff, Loader2 } from 'lucide-angular';
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule, FormsModule, MessageModule, LucideAngularModule],
+  imports: [CommonModule, FormsModule, RouterLink, MessageModule, LucideAngularModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-4">
@@ -66,6 +66,15 @@ import { LucideAngularModule, Eye, EyeOff, Loader2 } from 'lucide-angular';
                     <lucide-icon [name]="showPassword() ? eyeOffIcon : eyeIcon" size="20"></lucide-icon>
                   </button>
                 </div>
+              </div>
+
+              <div class="flex justify-end">
+                <a
+                  routerLink="/forgot-password"
+                  class="text-sm font-medium text-blue-300 hover:text-blue-200 transition-colors"
+                >
+                  Olvidé mi contraseña
+                </a>
               </div>
 
               <!-- Error Message -->

--- a/src/app/components/auth/reset-password/reset-password.component.ts
+++ b/src/app/components/auth/reset-password/reset-password.component.ts
@@ -1,0 +1,139 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { finalize } from 'rxjs';
+import { LucideAngularModule, ArrowLeft, Eye, EyeOff, Loader2 } from 'lucide-angular';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-reset-password',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink, LucideAngularModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-4">
+      <div class="w-full max-w-md">
+        <div class="bg-slate-800/80 backdrop-blur-sm border border-slate-700 rounded-2xl shadow-2xl overflow-hidden">
+          <div class="bg-gradient-to-r from-blue-600 to-indigo-600 text-white p-8 text-center">
+            <div class="flex items-center justify-center">
+              <img src="/assets/logos/Logotipo - Blanco.svg" alt="Rakium Logo" class="h-12 w-auto" />
+            </div>
+          </div>
+
+          <div class="p-8 pb-10">
+            <a routerLink="/login" class="inline-flex items-center gap-2 text-sm font-medium text-slate-300 hover:text-white transition-colors mb-6">
+              <lucide-icon [name]="arrowLeftIcon" size="18"></lucide-icon>
+              Volver al login
+            </a>
+
+            <div class="space-y-2 mb-8">
+              <h1 class="text-2xl font-semibold text-white">Nueva contraseña</h1>
+              <p class="text-sm text-slate-400">Elegí una contraseña nueva para volver a entrar a Rakium.</p>
+            </div>
+
+            <form (ngSubmit)="onSubmit()" class="space-y-6">
+              <div class="space-y-2">
+                <label for="password" class="block text-sm font-semibold text-slate-200">Contraseña</label>
+                <div class="relative">
+                  <input
+                    id="password"
+                    [type]="showPassword() ? 'text' : 'password'"
+                    placeholder="Mínimo 6 caracteres"
+                    [(ngModel)]="password"
+                    name="password"
+                    required
+                    minlength="6"
+                    class="w-full px-4 py-3 pr-12 bg-slate-700/60 border border-slate-500/50 rounded-xl text-white placeholder-slate-400 focus:border-blue-400 focus:ring-1 focus:ring-blue-400/30 transition-all duration-200"
+                  />
+                  <button
+                    type="button"
+                    class="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200 transition-colors"
+                    (click)="toggleShowPassword()"
+                    [attr.aria-label]="showPassword() ? 'Ocultar contraseña' : 'Ver contraseña'"
+                    tabindex="-1"
+                  >
+                    <lucide-icon [name]="showPassword() ? eyeOffIcon : eyeIcon" size="20"></lucide-icon>
+                  </button>
+                </div>
+              </div>
+
+              @if (message()) {
+                <div class="rounded-xl border border-emerald-700/70 bg-emerald-900/20 px-4 py-3 text-sm text-emerald-100">
+                  {{ message() }}
+                </div>
+              }
+
+              @if (errorMessage()) {
+                <div class="rounded-xl border border-red-800 bg-red-900/20 px-4 py-3 text-sm text-red-200">
+                  {{ errorMessage() }}
+                </div>
+              }
+
+              <button
+                type="submit"
+                [disabled]="loading() || password.length < 6"
+                class="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 disabled:from-slate-600 disabled:to-slate-700 text-white font-semibold py-4 px-8 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 flex items-center justify-center mt-2 disabled:cursor-not-allowed"
+              >
+                @if (!loading()) {
+                  <span>Actualizar contraseña</span>
+                } @else {
+                  <span class="flex items-center">
+                    <lucide-icon [name]="loaderIcon" size="20" class="animate-spin mr-2"></lucide-icon>
+                    Actualizando...
+                  </span>
+                }
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [`:host { display: block; }`],
+})
+export class ResetPasswordComponent {
+  private readonly authService = inject(AuthService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly token = this.route.snapshot.queryParamMap.get('token') || '';
+
+  password = '';
+  readonly loading = signal(false);
+  readonly message = signal('');
+  readonly errorMessage = signal('');
+  readonly showPassword = signal(false);
+
+  readonly arrowLeftIcon = ArrowLeft;
+  readonly eyeIcon = Eye;
+  readonly eyeOffIcon = EyeOff;
+  readonly loaderIcon = Loader2;
+
+  toggleShowPassword(): void {
+    this.showPassword.update((v) => !v);
+  }
+
+  onSubmit(): void {
+    if (this.password.length < 6 || this.loading()) return;
+
+    if (!this.token) {
+      this.errorMessage.set('El link de recuperación no es válido.');
+      return;
+    }
+
+    this.loading.set(true);
+    this.message.set('');
+    this.errorMessage.set('');
+
+    this.authService
+      .resetPassword(this.token, this.password)
+      .pipe(finalize(() => this.loading.set(false)))
+      .subscribe({
+        next: (response) => {
+          this.message.set(response.message);
+          setTimeout(() => this.router.navigate(['/login']), 1200);
+        },
+        error: () => this.errorMessage.set('El link no es válido o venció. Pedí uno nuevo.'),
+      });
+  }
+}

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -67,6 +67,20 @@ export class AuthService {
       );
   }
 
+  forgotPassword(email: string): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(
+      `${this.baseUrl}/auth/forgot-password`,
+      { email }
+    );
+  }
+
+  resetPassword(token: string, password: string): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(
+      `${this.baseUrl}/auth/reset-password`,
+      { token, password }
+    );
+  }
+
   logout(): void {
     if (isPlatformBrowser(this.platformId)) {
       localStorage.removeItem(TOKEN_KEY);

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  apiUrl: 'https://rakium-be-production.up.railway.app/api',
+  apiUrl: 'https://api.rakium.dev/api',
   rakiumClientId: 'a49284fc-c5cc-471e-a4f7-1fb71925c1e3',
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://rakium-backend-production.up.railway.app/api',
+  apiUrl: 'https://api.rakium.dev/api',
   rakiumClientId: 'a49284fc-c5cc-471e-a4f7-1fb71925c1e3',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://rakium-be-production.up.railway.app/api',
+  apiUrl: 'https://api.rakium.dev/api',
   rakiumClientId: 'a49284fc-c5cc-471e-a4f7-1fb71925c1e3',
 };


### PR DESCRIPTION
## Summary
- add forgot-password and reset-password screens to Rakium dev
- wire the auth service to the new Rakium backend reset endpoints
- point frontend API environments to https://api.rakium.dev/api

## Test
- ./node_modules/.bin/tsc -p tsconfig.app.json --noEmit

Note: npm run build and ng build --configuration=development hung without output in this local workspace, so I stopped the stuck ng processes after validating TypeScript.